### PR TITLE
Potential fix for code scanning alert no. 8: Uncontrolled data used in path expression

### DIFF
--- a/scripts/release-helper.mjs
+++ b/scripts/release-helper.mjs
@@ -1,5 +1,5 @@
 import { readdir, readFile } from 'fs/promises';
-import { join, resolve } from 'path';
+import { resolve } from 'path';
 import github from '@actions/github';
 import { exec } from './common.js';
 

--- a/scripts/release-helper.mjs
+++ b/scripts/release-helper.mjs
@@ -4,7 +4,9 @@ import github from '@actions/github';
 import { exec } from './common.js';
 
 const { VERSION, GITHUB_TOKEN } = process.env;
-const SAFE_ROOT_DIR = resolve('/path/to/trusted/root'); // Replace with the actual trusted root directory
+const SAFE_ROOT_DIR = resolve(process.env.SAFE_ROOT_DIR || (() => {
+  throw new Error('SAFE_ROOT_DIR environment variable is not set.');
+})());
 const ASSETS_DIR = (() => {
   const resolvedPath = resolve(SAFE_ROOT_DIR, process.env.ASSETS_DIR || '');
   if (!resolvedPath.startsWith(SAFE_ROOT_DIR)) {

--- a/scripts/release-helper.mjs
+++ b/scripts/release-helper.mjs
@@ -1,9 +1,17 @@
 import { readdir, readFile } from 'fs/promises';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import github from '@actions/github';
 import { exec } from './common.js';
 
-const { VERSION, ASSETS_DIR, GITHUB_TOKEN } = process.env;
+const { VERSION, GITHUB_TOKEN } = process.env;
+const SAFE_ROOT_DIR = resolve('/path/to/trusted/root'); // Replace with the actual trusted root directory
+const ASSETS_DIR = (() => {
+  const resolvedPath = resolve(SAFE_ROOT_DIR, process.env.ASSETS_DIR || '');
+  if (!resolvedPath.startsWith(SAFE_ROOT_DIR)) {
+    throw new Error(`Invalid ASSETS_DIR: ${process.env.ASSETS_DIR}`);
+  }
+  return resolvedPath;
+})();
 const tag = `v${VERSION}`;
 
 let octokit;


### PR DESCRIPTION
Potential fix for [https://github.com/Julieisbaka/Violentmonkey/security/code-scanning/8](https://github.com/Julieisbaka/Violentmonkey/security/code-scanning/8)

To fix the issue, we need to validate and sanitize the `ASSETS_DIR` value before using it in file system operations. A robust approach is to ensure that the directory path is resolved to a safe, predefined root directory. This can be achieved by:
1. Normalizing the `ASSETS_DIR` path using `path.resolve` to remove any `..` segments.
2. Verifying that the resolved path starts with the predefined root directory.
3. Rejecting or throwing an error if the validation fails.

The predefined root directory should be a trusted directory where assets are expected to be stored. This ensures that even if an attacker provides a malicious `ASSETS_DIR`, it cannot escape the trusted root directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
