### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete string escaping or encoding

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
     "@zip.js/zip.js": "2.4.4",
     "tldts": "^6.0.14",
     "vue": "^3.5.17",
-    "vueleton": "^2.0.2"
+    "vueleton": "^2.0.2",
+    "shell-escape": "^0.2.0"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/release-helper.mjs
+++ b/scripts/release-helper.mjs
@@ -2,6 +2,7 @@ import { readdir, readFile } from 'fs/promises';
 import { resolve } from 'path';
 import github from '@actions/github';
 import { exec } from './common.js';
+import shellEscape from 'shell-escape';
 
 const { VERSION, GITHUB_TOKEN } = process.env;
 const SAFE_ROOT_DIR = resolve(process.env.SAFE_ROOT_DIR || (() => {
@@ -39,7 +40,8 @@ function listCommits() {
   const thisTag = exec('git describe --abbrev=0 --tags');
   const prevTag = exec(`git describe --abbrev=0 --tags "${thisTag}^"`);
   const tagRange = `${prevTag}...${thisTag}`;
-  const list = exec(`git log --oneline --skip=1 --reverse "${tagRange}"`)
+  const escapedTagRange = shellEscape([tagRange]);
+  const list = exec(`git log --oneline --skip=1 --reverse ${escapedTagRange}`)
   .replace(/</g, '\\<')
   .split('\n')
   .map((str, i) => `${str.split(/\s/, 2)[1]}${10000 + i}\n* ${str}`)


### PR DESCRIPTION
Potential fix for [https://github.com/Julieisbaka/Violentmonkey/security/code-scanning/1](https://github.com/Julieisbaka/Violentmonkey/security/code-scanning/1)

To fix the issue, we need to ensure that the `tagRange` variable is properly escaped before being used in the shell command. The best approach is to use a library like `shell-escape` to safely escape the input. This library ensures that all special characters are properly handled, preventing injection attacks or unexpected behavior.

The changes involve:
1. Importing the `shell-escape` library.
2. Escaping the `tagRange` variable using `shell-escape` before embedding it into the shell command.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
