### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/transifex-push-translations.yml
+++ b/.github/workflows/transifex-push-translations.yml
@@ -1,5 +1,8 @@
 name: Upload translations to Transifex
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request_target:


### PR DESCRIPTION
Potential fix for [https://github.com/Julieisbaka/Violentmonkey/security/code-scanning/22](https://github.com/Julieisbaka/Violentmonkey/security/code-scanning/22)

To fix the issue, we need to add an explicit `permissions` block to the workflow. This block should define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it likely needs read access to repository contents and no additional write permissions. 

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `build` job. In this case, adding it at the root level is preferable for simplicity and consistency.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
